### PR TITLE
Use relpath in `go build`'s args for Go < 1.11

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,7 +127,7 @@ func (c *Config) createManager() (
 		builder = mod.NewBuilder(executor)
 		adder = mod.NewAdder(executor)
 	case ModeDep:
-		builder = dep.NewBuilder(executor, c.RootDir)
+		builder = dep.NewBuilder(executor, c.RootDir, c.WorkingDir)
 		adder = dep.NewAdder(executor)
 	default:
 		return nil, errors.New("failed to detect a dependencies management tool")

--- a/pkg/manager/dep/builder.go
+++ b/pkg/manager/dep/builder.go
@@ -3,6 +3,7 @@ package dep
 import (
 	"context"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -10,23 +11,33 @@ import (
 )
 
 // NewBuilder creates a manager.Builder instance to build tools vendored with dep.
-func NewBuilder(executor manager.Executor, rootDir string) manager.Builder {
+func NewBuilder(executor manager.Executor, rootDir, workingDir string) manager.Builder {
 	return &builderImpl{
-		executor: executor,
-		rootDir:  rootDir,
+		executor:   executor,
+		rootDir:    rootDir,
+		workingDir: workingDir,
 	}
 }
 
 type builderImpl struct {
-	executor manager.Executor
-	rootDir  string
+	executor   manager.Executor
+	rootDir    string
+	workingDir string
 }
 
 func (b *builderImpl) Build(ctx context.Context, binPath, pkg string, verbose bool) error {
+	target, err := filepath.Rel(b.workingDir, b.rootDir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	target = filepath.Join(target, "vendor", pkg)
+	if !strings.HasPrefix(target, "..") {
+		target = "." + string(filepath.Separator) + target
+	}
 	args := []string{"build", "-o", binPath}
 	if verbose {
 		args = append(args, "-v")
 	}
-	args = append(args, filepath.Join(b.rootDir, "vendor", pkg))
+	args = append(args, target)
 	return errors.WithStack(b.executor.Exec(ctx, "go", args...))
 }


### PR DESCRIPTION
## WHY

## WHAT

## REF

