### PR TITLE
Strip major version from import path

### DIFF
--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -1,11 +1,31 @@
 package tool
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+)
 
 // Tool represents a go package of a tool dependency.
 type Tool string
 
 // Name returns an executable name.
 func (t Tool) Name() string {
-	return filepath.Base(string(t))
+	lastSegment := filepath.Base(string(t))
+	if isVersionLike(lastSegment) {
+		// Likely a major version suffix
+		return filepath.Base(filepath.Dir(string(t)))
+	}
+	return lastSegment
+}
+
+func isVersionLike(segment string) bool {
+	if !strings.HasPrefix(segment, "v") {
+		return false
+	}
+	versionPart := strings.TrimPrefix(segment, "v")
+	if _, err := strconv.ParseUint(versionPart, 10, 64); err == nil {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
gex infers package name from its import path, but it goes wrong if major version suffix is involved.

```go
//go:generate go build -v -o=./bin/v4 github.com/volatiletech/sqlboiler/v4
```

This PR adds new heuristics to better infer the package name.

```go
//go:generate go build -v -o=./bin/sqlboiler github.com/volatiletech/sqlboiler/v4
```